### PR TITLE
feat: Pretty format for issues and MRs items

### DIFF
--- a/lua/cmp_git/github.lua
+++ b/lua/cmp_git/github.lua
@@ -58,7 +58,8 @@ M.get_issues = function(source, callback, bufnr, git_info)
                 issue.body = ""
             end
             return {
-                label = string.format("#%s", issue.number),
+                label = string.format("#%s: %s", issue.number, issue.title),
+                insertText = string.format("#%s", issue.number),
                 documentation = {
                     kind = "markdown",
                     value = string.format("# %s\n\n%s", issue.title, issue.body),

--- a/lua/cmp_git/gitlab.lua
+++ b/lua/cmp_git/gitlab.lua
@@ -51,7 +51,8 @@ M.get_issues = function(source, callback, bufnr, git_info)
             end
 
             return {
-                label = string.format("#%s", issue.iid),
+                label = string.format("#%s: %s", issue.iid, issue.title),
+                insertText = string.format("#%s", issue.iid),
                 documentation = {
                     kind = "markdown",
                     value = string.format("# %s\n\n%s", issue.title, issue.description),
@@ -165,7 +166,8 @@ M.get_mrs = function(source, callback, bufnr, git_info)
 
         local items = utils.handle_response(result, function(mr)
             return {
-                label = string.format("!%s", mr.iid),
+                label = string.format("!%s: %s", mr.iid, mr.title),
+                insertText = string.format("!%s", mr.iid),
                 documentation = {
                     kind = "markdown",
                     value = string.format("# %s\n\n%s", mr.title, mr.description),


### PR DESCRIPTION
This will add the title of an issue or MR to the completion item. But
the inserted text will stay the same.

Might look something like this:
![Screenshot_20211026_115801](https://user-images.githubusercontent.com/8257844/138856310-24cbc6bf-9a14-4078-b6e3-6fa115f8a0b0.png)

