### PR TITLE
feat: basic support for git commits #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,17 +9,25 @@ Git source for [hrsh7th/nvim-cmp](https://github.com/hrsh7th/nvim-cmp)
 
 ## Features
 
+| Git     | Trigger |
+| ------- | ------- |
+| commits | :       |
+
 | GitHub                 | Trigger |
 | ---------------------- | ------- |
-| issues                 | #       |
-| mentions (`curl` only) | @       |
-| pull requests          | #       |
+| Issues                 | #       |
+| Mentions (`curl` only) | @       |
+| Pull Requests          | #       |
 
 | GitLab         | Trigger |
 | -------------- | ------- |
-| issues         | #       |
-| mentions       | @       |
-| merge requests | !       |
+| Issues         | #       |
+| Mentions       | @       |
+| Merge Requests | !       |
+ 
+| Git         | Trigger |
+| ----------- | ------- |
+| Commits     | :       |
 
 ## Requirements
 
@@ -69,6 +77,11 @@ require("cmp").setup({
 require("cmp_git").setup({
     -- defaults
     filetypes = { "gitcommit" },
+    git = {
+        commits = {
+            limit = 100,
+        },
+    },
     github = {
         issues = {
             filter = "all", -- assigned, created, mentioned, subscribed, all, repos

--- a/lua/cmp_git/config.lua
+++ b/lua/cmp_git/config.lua
@@ -1,5 +1,10 @@
 local M = {
     filetypes = { "gitcommit" },
+    git = {
+        commits = {
+            limit = 100,
+        },
+    },
     github = {
         issues = {
             filter = "all", -- assigned, created, mentioned, subscribed, all, repos

--- a/lua/cmp_git/git.lua
+++ b/lua/cmp_git/git.lua
@@ -1,0 +1,118 @@
+local M = {}
+
+local remove_newline = function(str)
+    return string.gsub(str, "\n", "")
+end
+
+function trim(s)
+    return (s:gsub("^%s*(.-)%s*$", "%1"))
+end
+
+local split_by = function(input, sep)
+    local t = {}
+
+    while true do
+        local s, e = string.find(input, sep)
+
+        if not s then
+            break
+        end
+
+        local part = string.sub(input, 1, s - 1)
+        input = string.sub(input, e + 1)
+
+        table.insert(t, part)
+    end
+
+    return t
+end
+
+M.update_edit_range = function(commits, cursor, offset)
+    local updated = {}
+    for k, v in pairs(commits) do
+        local sha = v.insertText
+
+        local update = {
+            range = {
+                start = {
+                    line = cursor.row - 1,
+                    character = cursor.character - 1,
+                },
+                ["end"] = {
+                    line = cursor.row - 1,
+                    character = cursor.character + string.len(sha),
+                },
+            },
+            newText = sha,
+        }
+
+        commits[k].textEdit = update
+    end
+end
+
+M.get_git_commits = function(source, callback, bufnr, cursor, offset)
+    -- Choose unique and long end markers
+    local end_part_marker = "###CMP_GIT###"
+    local end_entry_marker = "###CMP_GIT_END###"
+
+    -- Extract abbreviated commit sha, subject, body, author name, author email, comit timestamp
+    local command = string.format(
+        'git log -n %d --pretty=format:"%%h%s%%s%s%%b%s%%cn%s%%ce%s%%cD%s%s"',
+        source.config.git.commits.limit,
+        end_part_marker,
+        end_part_marker,
+        end_part_marker,
+        end_part_marker,
+        end_part_marker,
+        end_part_marker,
+        end_entry_marker
+    )
+
+    local raw_output = vim.fn.system(command)
+    local commits = {}
+
+    local entries = split_by(raw_output, end_entry_marker)
+
+    for i, e in ipairs(entries) do
+        local part = split_by(e, end_part_marker)
+
+        local sha = trim(part[1])
+        local title = trim(part[2])
+        local description = trim(part[3]) or ""
+        local author_name = part[4] or ""
+        local author_mail = part[5] or ""
+        local commit_time = part[6] or ""
+
+        table.insert(commits, {
+            label = string.format("%s: %s", sha, title),
+            insertText = sha,
+            documentation = {
+                kind = "markdown",
+                value = string.format(
+                    "# %s\n\n%s\n\nCommited by %s (%s) on %s",
+                    title,
+                    description,
+                    author_name,
+                    author_mail,
+                    commit_time
+                ),
+            },
+            data = {
+                sha = sha,
+                title = title,
+                description = description,
+                author_name = author_name,
+                author_mail = author_mail,
+                commit_time = commit_time,
+            },
+        })
+    end
+
+    M.update_edit_range(commits, cursor, offset)
+
+    callback({ items = commits, isIncomplete = false })
+
+    source.cache_commits[bufnr] = commits
+end
+
+return M

--- a/lua/cmp_git/utils.lua
+++ b/lua/cmp_git/utils.lua
@@ -8,6 +8,7 @@ M.url_encode = function(value)
     return string.gsub(value, "([^%w _%%%-%.~])", char_to_hex)
 end
 
+
 M.get_git_info = function()
     return M.run_in_cwd(M.get_cwd(), function()
         local remote_origin_url = vim.fn.system("git config --get remote.origin.url")


### PR DESCRIPTION
This is still a little incomplete.

If I include the title in the label, cmp will match for the titles of commits, which is not what I would expect and it gets really annoying quickly, maybe there is a different field just for display, but idk. 

Second, I haven't found a nice way to include the descriptions. In theory, one could add `%b` in the git log call, but I haven't found a nice way to split it all up. It gets messy quickly, so let's start with this :-)

And a little screenshot for good measures: 
![Screenshot_20211026_132953](https://user-images.githubusercontent.com/8257844/138870009-5fd8f737-b764-43e9-aea9-d7b9df49134a.png)
