### PR TITLE
Use vim.schedule_wrap to avoid default `vim.notify` error

### DIFF
--- a/lua/cmp_git/github.lua
+++ b/lua/cmp_git/github.lua
@@ -29,13 +29,13 @@ local get_command = function(callback, gh_command, curl_url, handle_item)
     end
 
     command.cwd = utils.get_cwd()
-    command.on_exit = function(job)
+    command.on_exit = vim.schedule_wrap(function(job)
         local result = table.concat(job:result(), "")
 
         local items = utils.handle_response(result, handle_item)
 
         callback({ items = items, isIncomplete = false })
-    end
+    end)
 
     return command
 end

--- a/lua/cmp_git/gitlab.lua
+++ b/lua/cmp_git/gitlab.lua
@@ -31,13 +31,13 @@ local get_items = function(callback, glab_command, curl_url, handle_item)
     end
 
     command.cwd = utils.get_cwd()
-    command.on_exit = function(job)
+    command.on_exit = vim.schedule_wrap(function(job)
         local result = table.concat(job:result(), "")
 
         local items = utils.handle_response(result, handle_item)
 
         callback({ items = items, isIncomplete = false })
-    end
+    end)
 
     Job:new(command):start()
 end


### PR DESCRIPTION
The default `vim.notify` use `vim.nvim_echo` internally. It requires `scheduled` context.