### PR TITLE
feat: add support for checking for multiple remotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ require("cmp").setup({
 require("cmp_git").setup({
     -- defaults
     filetypes = { "gitcommit" },
-    remote = "origin",
+    remotes = { "upstream", "origin" }, -- in order of most to least prioritized
     git = {
         commits = {
             limit = 100,

--- a/lua/cmp_git/config.lua
+++ b/lua/cmp_git/config.lua
@@ -1,6 +1,6 @@
 local M = {
     filetypes = { "gitcommit" },
-    remote = "origin",
+    remotes = { "upstream", "origin" }, -- in order of most to least prioritized
     git = {
         commits = {
             limit = 100,

--- a/lua/cmp_git/git.lua
+++ b/lua/cmp_git/git.lua
@@ -28,7 +28,6 @@ local split_by = function(input, sep)
 end
 
 M.update_edit_range = function(commits, cursor, offset)
-    local updated = {}
     for k, v in pairs(commits) do
         local sha = v.insertText
 

--- a/lua/cmp_git/source.lua
+++ b/lua/cmp_git/source.lua
@@ -43,10 +43,10 @@ function Source:complete(params, callback)
         trigger_character = params.completion_context.triggerCharacter
     end
 
-    local git_info = utils.get_git_info(self.config.remote)
-
     if trigger_character == ":" then
         if not self.cache_commits[bufnr] then
+            local git_info = utils.get_git_info(self.config.remotes)
+
             if self.config.git and self.config.git.commits then
                 git.get_git_commits(self, callback, bufnr, params.context.cursor, params.offset)
             else
@@ -59,6 +59,8 @@ function Source:complete(params, callback)
         end
     elseif trigger_character == "#" then
         if not self.cache_issues[bufnr] then
+            local git_info = utils.get_git_info(self.config.remotes)
+
             if
                 self.config.github
                 and self.config.github.issues
@@ -84,6 +86,8 @@ function Source:complete(params, callback)
         end
     elseif trigger_character == "@" then
         if not self.cache_mentions[bufnr] then
+            local git_info = utils.get_git_info(self.config.remotes)
+
             if
                 self.config.github
                 and self.config.github.mentions
@@ -109,6 +113,8 @@ function Source:complete(params, callback)
         end
     elseif trigger_character == "!" then
         if not self.cache_merge_requests[bufnr] then
+            local git_info = utils.get_git_info(self.config.remotes)
+
             if
                 self.config.gitlab
                 and self.config.gitlab.mentions

--- a/lua/cmp_git/utils.lua
+++ b/lua/cmp_git/utils.lua
@@ -8,15 +8,30 @@ M.url_encode = function(value)
     return string.gsub(value, "([^%w _%%%-%.~])", char_to_hex)
 end
 
-M.get_git_info = function(remote)
+M.get_git_info = function(remotes)
     return M.run_in_cwd(M.get_cwd(), function()
-        local remote_origin_url = vim.fn.system("git config --get remote." .. remote .. ".url")
-        local clean_remote_origin_url = remote_origin_url:gsub("%.git", ""):gsub("%s", "")
+        if type(remotes) == "string" then
+            remotes = { remotes }
+        end
 
-        local host, owner, repo = string.match(clean_remote_origin_url, "^git@(.+):(.+)/(.+)$")
+        local host, owner, repo = nil, nil, nil
 
-        if host == nil then
-            host, owner, repo = string.match(clean_remote_origin_url, "^https?://(.+)/(.+)/(.+)$")
+        for _, r in ipairs(remotes) do
+            local remote_origin_url = vim.fn.system("git config --get remote." .. r .. ".url")
+
+            if remote_origin_url ~= "" then
+                local clean_remote_origin_url = remote_origin_url:gsub("%.git", ""):gsub("%s", "")
+
+                host, owner, repo = string.match(clean_remote_origin_url, "^git@(.+):(.+)/(.+)$")
+
+                if host == nil then
+                    host, owner, repo = string.match(clean_remote_origin_url, "^https?://(.+)/(.+)/(.+)$")
+                end
+
+                if host ~= nil and owner ~= nil and repo ~= nil then
+                    break
+                end
+            end
         end
 
         return { host = host, owner = owner, repo = repo }


### PR DESCRIPTION
This improves on #25

Allows user to specify a list of remotes in order of most to least prioritized. `cmp-git` will try to retrieve git info (host, owner, repo) using this list. It currently only supports retrieving data from 1 remote though