### PR TITLE
Optionally use git-remote to determine remote URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ require("cmp_git").setup({
     -- defaults
     filetypes = { "gitcommit" },
     remotes = { "upstream", "origin" }, -- in order of most to least prioritized
+    enableRemoteUrlRewrites = false, -- enable git url rewrites, see https://git-scm.com/docs/git-config#Documentation/git-config.txt-urlltbasegtinsteadOf
     git = {
         commits = {
             sort_by = function(commit) -- nil, "sha", "title", "description", "author_name", "author_email", "commit_timestamp", or custom function

--- a/lua/cmp_git/config.lua
+++ b/lua/cmp_git/config.lua
@@ -3,6 +3,7 @@ local utils = require("cmp_git.utils")
 local M = {
     filetypes = { "gitcommit" },
     remotes = { "upstream", "origin" }, -- in order of most to least prioritized
+    enableRemoteUrlRewrites = false, -- enable git url rewrites, see https://git-scm.com/docs/git-config#Documentation/git-config.txt-urlltbasegtinsteadOf
     git = {
         commits = {
             limit = 100,

--- a/lua/cmp_git/source.lua
+++ b/lua/cmp_git/source.lua
@@ -52,7 +52,10 @@ function Source:complete(params, callback)
 
     for _, trigger in pairs(self.trigger_actions) do
         if trigger.trigger_character == trigger_character then
-            local git_info = utils.get_git_info(self.config.remotes)
+            local git_info = utils.get_git_info(
+                self.config.remotes,
+                { enableRemoteUrlRewrites = self.config.enableRemoteUrlRewrites }
+            )
 
             if trigger.action(self.sources, trigger_character, callback, params, git_info) then
                 break

--- a/lua/cmp_git/utils.lua
+++ b/lua/cmp_git/utils.lua
@@ -42,7 +42,8 @@ M.parse_github_date = function(d)
     })
 end
 
-M.get_git_info = function(remotes)
+M.get_git_info = function(remotes, opts)
+    opts = opts or {}
     return M.run_in_cwd(M.get_cwd(), function()
         if type(remotes) == "string" then
             remotes = { remotes }
@@ -51,7 +52,13 @@ M.get_git_info = function(remotes)
         local host, owner, repo = nil, nil, nil
 
         for _, r in ipairs(remotes) do
-            local remote_origin_url = vim.fn.system("git config --get remote." .. r .. ".url")
+            local cmd
+            if opts.enableRemoteUrlRewrites then
+                cmd = "git remote get-url " .. r
+            else
+                cmd = "git config --get remote." .. r .. ".url"
+            end
+            local remote_origin_url = vim.fn.system(cmd)
 
             if remote_origin_url ~= "" then
                 local clean_remote_origin_url = remote_origin_url:gsub("%.git", ""):gsub("%s", "")


### PR DESCRIPTION
When using `git config --get remote.<remote>.url`, git does not apply rewrite rules that the user may have configured using `url.<base>.insteadOf`.

On the other hand, using `git remote get-url` does apply rewrite rules.

This change keeps the existing behavior by default, but allows users to enable rewrites if desired by setting `config.enableRemoteUrlRewrites` to `true`.

For more information on git url rewrites, see:
https://git-scm.com/docs/git-config#Documentation/git-config.txt-urlltbasegtinsteadOf