### PR TITLE
feat: detect ssh://git@... additionally

### DIFF
--- a/lua/cmp_git/utils.lua
+++ b/lua/cmp_git/utils.lua
@@ -94,6 +94,10 @@ M.get_git_info = function(remotes, opts)
                         host, owner, repo = string.match(clean_remote_origin_url, "^https?://(.+)/(.+)/(.+)$")
                     end
 
+                    if host == nil then
+                        host, owner, repo = string.match(clean_remote_origin_url, "^ssh://git@(.+)/(.+)/(.+)$")
+                    end
+
                     if host ~= nil and owner ~= nil and repo ~= nil then
                         break
                     end


### PR DESCRIPTION
The build in `main` only detects `git@(host):(org)/(repo)` for SSH access. But `ssh://git@(host)/(org)/(repo)` is also valid. This adds it.