### PR TITLE
fix: ssh port in remote url

### DIFF
--- a/lua/cmp_git/utils.lua
+++ b/lua/cmp_git/utils.lua
@@ -95,7 +95,7 @@ M.get_git_info = function(remotes, opts)
                     end
 
                     if host == nil then
-                        host, owner, repo = string.match(clean_remote_origin_url, "^ssh://git@(.+)/(.+)/(.+)$")
+                        host, owner, repo = string.match(clean_remote_origin_url, "^ssh://git@([^:]+):*.*/(.+)/(.+)$")
                     end
 
                     if host ~= nil and owner ~= nil and repo ~= nil then


### PR DESCRIPTION
Hi, 

We have a non standard port for our ssh remote, therefore the host detection does not work correctly.
This MR fixes this by ignoring an optional port.

Example remote:

```
ssh://git@git.my-company.com:11111/group/repo.git
```

I tested this MR locally and it is working now for our remote with non-default port.