### PR TITLE
hotfix: enable to call Enterprise from octo buffer

### DIFF
--- a/lua/cmp_git/utils.lua
+++ b/lua/cmp_git/utils.lua
@@ -72,7 +72,7 @@ M.get_git_info = function(remotes, opts)
         local host, owner, repo = nil, nil, nil
 
         if vim.bo.filetype == "octo" then
-            host = "github.com"
+            host = require("octo.config").get_config().github_hostname
             local filename = vim.fn.expand("%:p:h")
             owner, repo = string.match(filename, "^octo://(.+)/(.+)/.+$")
         else


### PR DESCRIPTION
The current build uses github.com always in octo buffers, so it cannot get candidates from GitHub Enterprise. To solve this, this fix gets the hostname from `octo.config` module.