### PR TITLE
fix #53: Issue and PR autocomplete not working in Octo files

### DIFF
--- a/lua/cmp_git/utils.lua
+++ b/lua/cmp_git/utils.lua
@@ -116,6 +116,11 @@ M.get_git_info = function(remotes, opts)
         git_info = get_git_info()
     end
 
+    if (git_info.host or "") == "" then
+        -- fallback to github.com
+        git_info.host = "github.com"
+    end
+
     return git_info
 end
 

--- a/lua/cmp_git/utils.lua
+++ b/lua/cmp_git/utils.lua
@@ -72,7 +72,10 @@ M.get_git_info = function(remotes, opts)
         local host, owner, repo = nil, nil, nil
 
         if vim.bo.filetype == "octo" then
-            host = require("octo.config").get_config().github_hostname
+            host = require("octo.config").values.github_hostname or ""
+            if host == "" then
+                host = "github.com"
+            end
             local filename = vim.fn.expand("%:p:h")
             owner, repo = string.match(filename, "^octo://(.+)/(.+)/.+$")
         else
@@ -114,11 +117,6 @@ M.get_git_info = function(remotes, opts)
     if git_info.host == nil then
         -- fallback to cwd
         git_info = get_git_info()
-    end
-
-    if (git_info.host or "") == "" then
-        -- fallback to github.com
-        git_info.host = "github.com"
     end
 
     return git_info


### PR DESCRIPTION
Let me know if you have any questions. I don't have any Lua experience but seems pretty straight forward.

The issue seems to be that this commit 7b292e1 was pushed to account for GH Enterprise URLs, but Octo default settings leaves this config item (`github_hostname`) empty by default. I added a fallback of `github.com` if it is empty.

![image](https://github.com/petertriho/cmp-git/assets/64155612/9ecae4e2-29ca-45b6-9977-a28f545aff4e)

Additionally Octo just made a change to their API so had to replace `get_config()` with `values`... see here: https://github.com/pwntester/octo.nvim/commit/b5371003f209764c9d1cc43cf20b6dc52961f0e8

ref: #53 