### PR TITLE
feat: use gh repo set-default if set for GitHub

### DIFF
--- a/lua/cmp_git/sources/github.lua
+++ b/lua/cmp_git/sources/github.lua
@@ -149,6 +149,19 @@ local get_issues_job = function(callback, git_info, trigger_char, config)
     )
 end
 
+local use_gh_default_repo_if_set = function(git_info)
+    local gh_default_repo = vim.fn.system({ 'gh', 'repo', 'set-default', '--view' })
+    if vim.v.shell_error ~= 0 then
+        return git_info
+    end
+    local owner, repo = string.match(vim.fn.trim(gh_default_repo), "^(.+)/(.+)$")
+    if owner ~= nil and repo ~= nil then
+        git_info.owner = owner
+        git_info.repo = repo
+    end
+    return git_info
+end
+
 function GitHub:is_valid_host(git_info)
     if
         git_info.host == nil
@@ -200,6 +213,8 @@ function GitHub:get_issues(callback, git_info, trigger_char)
         return false
     end
 
+    git_info = use_gh_default_repo_if_set(git_info)
+
     local job = self:_get_issues(callback, git_info, trigger_char)
 
     if job then
@@ -214,6 +229,8 @@ function GitHub:get_pull_requests(callback, git_info, trigger_char)
         return false
     end
 
+    git_info = use_gh_default_repo_if_set(git_info)
+
     local job = self:_get_pull_requests(callback, git_info, trigger_char)
 
     if job then
@@ -227,6 +244,8 @@ function GitHub:get_issues_and_prs(callback, git_info, trigger_char)
     if not GitHub:is_valid_host(git_info) then
         return false
     end
+
+    git_info = use_gh_default_repo_if_set(git_info)
 
     local bufnr = vim.api.nvim_get_current_buf()
 


### PR DESCRIPTION
When working in a fork of a GitHub repo, depending on how the remotes are configured locally, completion of issues and pull requests may not work because the fork is being used for the  lookup.

This patch checks the value of `gh repo set-default --view` and uses that instead of the git info discovered in the `cmp_git.utils.git_git_info()` function. If the default repo has not previously been configured, the command to view it will fail no change is made to the git info.