### PR TITLE
Allow completion to insert unabbreviated commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ require("cmp_git").setup({
             limit = 100,
             sort_by = sort.git.commits,
             format = format.git.commits,
+            abbreviate = true,
         },
     },
     github = {

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ require("cmp_git").setup({
             limit = 100,
             sort_by = sort.git.commits,
             format = format.git.commits,
-            abbreviate = true,
+            sha_length = 7,
         },
     },
     github = {

--- a/lua/cmp_git/config.lua
+++ b/lua/cmp_git/config.lua
@@ -10,7 +10,7 @@ local M = {
             limit = 100,
             sort_by = sort.git.commits,
             format = format.git.commits,
-            abbreviate = true,
+            sha_length = 7,
         },
     },
     github = {

--- a/lua/cmp_git/config.lua
+++ b/lua/cmp_git/config.lua
@@ -10,6 +10,7 @@ local M = {
             limit = 100,
             sort_by = sort.git.commits,
             format = format.git.commits,
+            abbreviate = true,
         },
     },
     github = {

--- a/lua/cmp_git/format.lua
+++ b/lua/cmp_git/format.lua
@@ -4,11 +4,11 @@ local M = {
     git = {
         commits = {
             label = function(trigger_char, commit)
-                return string.format("%s: %s", commit.sha, commit.title)
+                return string.format("%s: %s", commit.sha:sub(0, 7), commit.title)
             end,
             filterText = function(trigger_char, commit)
                 -- If the trigger char is not part of the label, no items will show up
-                return string.format("%s %s %s", trigger_char, commit.sha, commit.title)
+                return string.format("%s %s %s", trigger_char, commit.sha:sub(0, 7), commit.title)
             end,
             insertText = function(trigger_char, commit)
                 return commit.sha

--- a/lua/cmp_git/sources/git.lua
+++ b/lua/cmp_git/sources/git.lua
@@ -105,7 +105,7 @@ local parse_commits = function(trigger_char, callback, config)
                 for _, e in ipairs(entries) do
                     local part = split_by(e, end_part_marker)
 
-                    local sha = trim(part[1]):sub(0, config.abbreviate and 7 or 40)
+                    local sha = trim(part[1]):sub(0, config.sha_length)
                     local title = trim(part[2])
                     local description = trim(part[3]) or ""
                     local author_name = part[4] or ""

--- a/lua/cmp_git/sources/git.lua
+++ b/lua/cmp_git/sources/git.lua
@@ -81,7 +81,7 @@ local parse_commits = function(trigger_char, callback, config)
             config.limit,
             "--date=unix",
             string.format(
-                "--pretty=format:%%h%s%%s%s%%b%s%%cn%s%%ce%s%%cd%s%s",
+                "--pretty=format:%%H%s%%s%s%%b%s%%cn%s%%ce%s%%cd%s%s",
                 end_part_marker,
                 end_part_marker,
                 end_part_marker,

--- a/lua/cmp_git/sources/git.lua
+++ b/lua/cmp_git/sources/git.lua
@@ -105,7 +105,7 @@ local parse_commits = function(trigger_char, callback, config)
                 for _, e in ipairs(entries) do
                     local part = split_by(e, end_part_marker)
 
-                    local sha = trim(part[1])
+                    local sha = trim(part[1]):sub(0, config.abbreviate and 7 or 40)
                     local title = trim(part[2])
                     local description = trim(part[3]) or ""
                     local author_name = part[4] or ""


### PR DESCRIPTION
When rendering commit messages on forges (at least GitHub), the commit hash is automatically truncated and hyperlinked. However, if the commit hash is already truncated then the forge does not recognise it as such and so does not hyperlink it.

This change adds a new `git.commits.abbreviate` boolean that controls if the commit is inserted in full or abbreviated (defaulting to true to preserve existing behaviour). It does not change the completion list which always displays the abbreviated commit hash.