### PR TITLE
Allow unusual username in remote URL

### DIFF
--- a/lua/cmp_git/utils.lua
+++ b/lua/cmp_git/utils.lua
@@ -91,7 +91,7 @@ M.get_git_info = function(remotes, opts)
                 if remote_origin_url ~= "" then
                     local clean_remote_origin_url = remote_origin_url:gsub("%.git", ""):gsub("%s", "")
 
-                    host, owner, repo = string.match(clean_remote_origin_url, "^git@(.+):(.+)/(.+)$")
+                    host, owner, repo = string.match(clean_remote_origin_url, "^git.*@(.+):(.+)/(.+)$")
 
                     if host == nil then
                         host, owner, repo = string.match(clean_remote_origin_url, "^https?://(.+)/(.+)/(.+)$")


### PR DESCRIPTION
Some private providers may use 'gitlab' as the SSH user.