### PR TITLE
feat: add ssh aliases config

### DIFF
--- a/lua/cmp_git/config.lua
+++ b/lua/cmp_git/config.lua
@@ -5,6 +5,7 @@ local M = {
     filetypes = { "gitcommit", "octo", "NeogitCommitMessage" },
     remotes = { "upstream", "origin" }, -- in order of most to least prioritized
     enableRemoteUrlRewrites = false, -- enable git url rewrites, see https://git-scm.com/docs/git-config#Documentation/git-config.txt-urlltbasegtinsteadOf
+    ssh_aliases = {},
     git = {
         commits = {
             limit = 100,

--- a/lua/cmp_git/source.lua
+++ b/lua/cmp_git/source.lua
@@ -54,10 +54,10 @@ function Source:complete(params, callback)
 
     for _, trigger in pairs(self.trigger_actions) do
         if trigger.trigger_character == trigger_character then
-            local git_info = utils.get_git_info(
-                self.config.remotes,
-                { enableRemoteUrlRewrites = self.config.enableRemoteUrlRewrites }
-            )
+            local git_info = utils.get_git_info(self.config.remotes, {
+                enableRemoteUrlRewrites = self.config.enableRemoteUrlRewrites,
+                ssh_aliases = self.config.ssh_aliases,
+            })
 
             if trigger.action(self.sources, trigger_character, callback, params, git_info) then
                 break

--- a/lua/cmp_git/utils.lua
+++ b/lua/cmp_git/utils.lua
@@ -61,7 +61,10 @@ M.is_git_repo = function()
     return is_git_repo
 end
 
-M.get_git_info = function(remotes, opts)
+---@param remotes string|string[]
+---@param opts {enableRemoteUrlRewrites: boolean, ssh_aliases: {[string]: string}}
+---@return {host: string?, owner: string?, repo: string?}
+function M.get_git_info(remotes, opts)
     opts = opts or {}
 
     local get_git_info = function()
@@ -101,10 +104,20 @@ M.get_git_info = function(remotes, opts)
                         host, owner, repo = string.match(clean_remote_origin_url, "^ssh://git@([^:]+):*.*/(.+)/(.+)$")
                     end
 
+                    if host == nil then
+                        host, owner, repo = string.match(clean_remote_origin_url, "^([^:]+):(.+)/(.+)$")
+                    end
+
                     if host ~= nil and owner ~= nil and repo ~= nil then
                         break
                     end
                 end
+            end
+        end
+
+        if host ~= nil then
+            for alias, rhost in pairs(opts.ssh_aliases) do
+                host = host:gsub("^" .. alias:gsub("%-", "%%-"):gsub("%.", "%%.") .. "$", rhost, 1)
             end
         end
 


### PR DESCRIPTION
Create config `ssh_aliases` (similar to `octo.nvim`) for replacing ssh aliases with the original hostname.
