### PR TITLE
fix: add back support for github issue filter option

### DIFF
--- a/lua/cmp_git/config.lua
+++ b/lua/cmp_git/config.lua
@@ -38,9 +38,12 @@ local M = {
         issues = {
             ---@type string[]
             fields = { "title", "number", "body", "updatedAt", "state" },
-            filter = "all", -- assigned, created, mentioned, subscribed, all, repos
+            ---Filter by preconfigured options ('all', 'assigned', 'created', 'mentioned')
+            ---@type 'all' | 'assigned' | 'created' | 'mentioned'
+            filter = "all",
             limit = 100,
-            state = "open", -- open, closed, all
+            ---@type 'open' | 'closed' | 'all'
+            state = "open",
             sort_by = sort.github.issues,
             format = format.github.issues,
         },


### PR DESCRIPTION
The filter config for issues didn't work due to incorrect API usage on both the curl and gh cli commands. I assume this was referring to the issue search across all repos that the user has access to, but I don't think we should support this anyways. With this, we now support the following filters:
- `all`: all issues in the repo
- `assigned`: issues assigned to the user
- `created`: issues created by the user
- `mentioned`: issues mentioning the user

`repo` and `subscribed` were not added since it isn't supported by the API we are using. Though I could see potential for a search method where an arbitrary search can be used to give back matching issues.
