### PR TITLE
fix: use limit for mentions

### DIFF
--- a/lua/cmp_git/sources/github.lua
+++ b/lua/cmp_git/sources/github.lua
@@ -364,7 +364,13 @@ function GitHub:get_mentions(callback, git_info, trigger_char)
         end,
         {
             "api",
-            string.format("repos/%s/%s/contributors", git_info.owner, git_info.repo),
+            string.format(
+                "repos/%s/%s/contributors?per_page=%d&page=%d",
+                git_info.owner,
+                git_info.repo,
+                config.limit,
+                1
+            ),
             "--hostname",
             git_info.host,
         },


### PR DESCRIPTION
The mentions github source method was not using the limit config for fetching when using the `gh` cli, which meant that the default limit of 30 was used. This adds the query params so that the limit is used and symmetrical with the `curl` command.