### PR TITLE
fix: properly parse octo buffer name for repo info

### DIFF
--- a/lua/cmp_git/utils.lua
+++ b/lua/cmp_git/utils.lua
@@ -90,7 +90,7 @@ function M.get_git_info(remotes, opts)
                 host = "github.com"
             end
             local filename = vim.fn.expand("%:p:h")
-            owner, repo = string.match(filename, "^octo://(.+)/(.+)/.+$")
+            owner, repo = string.match(filename, "^octo://([^/]+)/([^/]+)")
         else
             for _, remote in ipairs(remotes) do
                 local cmd


### PR DESCRIPTION
The octo buffer name can include many forward slashes to include various additional info for the contents of the buffer. For example, for a PR review thread, the buffer name can be octo://ghostty-org/ghostty/review/PRR_kwDOHFhdAs6XHuqz/threads/RIGHT/src/shell-integration. The current regex would match incorrectly with these buffer names, e.g. for the aforementioned named the owner would be `ghostty-org/ghostty/review/PRR_kwDOHFhdAs6XHuqz/threads/RIGHT/src` and the repo would be `shell-integration`. Thus we need to make sure to only match with the first two parts of the path, e.g. `ghostty-org` and `ghostty` for the owner and repo respectively.

