### PR TITLE
feat: support up to infinite mentions

### DIFF
--- a/lua/cmp_git/config.lua
+++ b/lua/cmp_git/config.lua
@@ -48,6 +48,7 @@ local M = {
             format = format.github.issues,
         },
         mentions = {
+            -- Use math.huge to fetch until there are no more results
             limit = 100,
             sort_by = sort.github.mentions,
             format = format.github.mentions,


### PR DESCRIPTION
### Problem

There can be more than 100 users in a repository, but it's currently not possible to fetch more than 100 users.

### Solution

Allow fetching up to `math.huge` users, while not blocking for all the users to be fetched to return results.
